### PR TITLE
Fix setUiConfiguration input object usage

### DIFF
--- a/src/android/com/voxeet/toolkit/VoxeetCordova.java
+++ b/src/android/com/voxeet/toolkit/VoxeetCordova.java
@@ -510,27 +510,27 @@ public class VoxeetCordova extends CordovaPlugin {
         Users cusers = configuration.Users;
         if (null != actionBar) {
             if (actionBar.has("displayMute"))
-                cactionBar.displayMute = bool(object, "displayMute");
+                cactionBar.displayMute = bool(actionBar, "displayMute");
             if (actionBar.has("displaySpeaker"))
-                cactionBar.displaySpeaker = bool(object, "displaySpeaker");
+                cactionBar.displaySpeaker = bool(actionBar, "displaySpeaker");
             if (actionBar.has("displayCamera"))
-                cactionBar.displayCamera = bool(object, "displayCamera");
+                cactionBar.displayCamera = bool(actionBar, "displayCamera");
             if (actionBar.has("displayScreenShare"))
-                cactionBar.displayScreenShare = bool(object, "displayScreenShare");
+                cactionBar.displayScreenShare = bool(actionBar, "displayScreenShare");
             if (actionBar.has("displayLeave"))
-                cactionBar.displayLeave = bool(object, "displayLeave");
+                cactionBar.displayLeave = bool(actionBar, "displayLeave");
         }
         if (null != overlay) {
-            if (object.has("backgroundMaximizedColor"))
-                coverlay.background_maximized_color = integer(object, "backgroundMaximizedColor");
-            if (actionBar.has("backgroundMinimizedColor"))
-                coverlay.background_minimized_color = integer(object, "backgroundMinimizedColor");
+            if (overlay.has("backgroundMaximizedColor"))
+                coverlay.background_maximized_color = integer(overlay, "backgroundMaximizedColor");
+            if (overlay.has("backgroundMinimizedColor"))
+                coverlay.background_minimized_color = integer(overlay, "backgroundMinimizedColor");
         }
         if (null != users) {
-            if (object.has("speakingUserColor"))
-                cusers.speaking_user_color = integer(object, "speakingUserColor");
-            if (actionBar.has("selectedUserColor"))
-                cusers.selected_user_color = integer(object, "selectedUserColor");
+            if (users.has("speakingUserColor"))
+                cusers.speaking_user_color = integer(users, "speakingUserColor");
+            if (users.has("selectedUserColor"))
+                cusers.selected_user_color = integer(users, "selectedUserColor");
         }
     }
 


### PR DESCRIPTION
The 'object' parameter passed to the android native setUiConfiguration is expected to conform to the non-native (Configuration interface)[https://github.com/voxeet/voxeet-uxkit-cordova/blob/master/www/Configurations.d.ts], but it then does not use the object as the expected structure would require.

This PR modifies the android native setUiConfiguration function to update the ui configuration to the expected input object sub-keys.